### PR TITLE
don't use inline source maps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
     entry: 'semver',
-    devtool: 'inline-source-map',
+    devtool: 'source-map',
     mode: 'production',
     output: {
         path: path.resolve(__dirname, 'lib'),


### PR DESCRIPTION
@bpasero I've took a liberty to apply our learnings from `iconv-lite-umd` here as well.

Results are huge - we are saving almost 100 KiB!

**Before**
```
        Asset     Size
semver-umd.js  111 KiB
```

**After**
```
            Asset      Size
    semver-umd.js  16.9 KiB
semver-umd.js.map  70.3 KiB
```